### PR TITLE
Add `CList` for representing list literal expressions

### DIFF
--- a/src/AbstractCurry/Pretty.curry
+++ b/src/AbstractCurry/Pretty.curry
@@ -712,6 +712,8 @@ ppCExpr' p opts (CDoExpr stms) =
                             funcNamesOfStat
                             stms
                             opts
+ppCExpr' _ opts (CList exps) =
+    brackets $ hsep $ punctuate (comma <> space) (ppCExpr opts <$> exps)
 ppCExpr' _ opts (CListComp exp stms) =
     brackets $ hsep [ ppCExpr expOpts exp, bar
                     , hsep $ punctuate (comma <> space)

--- a/src/AbstractCurry/Select.curry
+++ b/src/AbstractCurry/Select.curry
@@ -250,6 +250,7 @@ varsOfExp (CApply e1 e2)      = varsOfExp e1 ++ varsOfExp e2
 varsOfExp (CLambda pl le)     = concatMap varsOfPat pl ++ varsOfExp le
 varsOfExp (CLetDecl ld le)    = concatMap varsOfLDecl ld ++ varsOfExp le
 varsOfExp (CDoExpr sl)        = concatMap varsOfStat sl
+varsOfExp (CList es)          = concatMap varsOfExp es
 varsOfExp (CListComp le sl)   = varsOfExp le ++ concatMap varsOfStat sl
 varsOfExp (CCase _ ce bl)     =
   varsOfExp ce ++ concatMap (\ (p,rhs) -> varsOfPat p ++ varsOfRhs rhs) bl

--- a/src/AbstractCurry/Types.curry
+++ b/src/AbstractCurry/Types.curry
@@ -269,6 +269,7 @@ data CExpr
  | CLambda    [CPattern] CExpr                   -- lambda abstraction
  | CLetDecl   [CLocalDecl] CExpr                 -- local let declarations
  | CDoExpr    [CStatement]                       -- do expression
+ | CList      [CExpr]                            -- list
  | CListComp  CExpr [CStatement]                 -- list comprehension
  | CCase      CCaseType CExpr [(CPattern, CRhs)] -- case expression
  | CTyped     CExpr CQualTypeExpr                -- typed expression


### PR DESCRIPTION
This adds `CList` to `CExpr`, for representing list literals (i.e. `[e1, e2, ...]`). This came up while working on https://github.com/fwcd/curry-lsp/pull/10 and since it might be useful for other code generators too, this adds it to `AbstractCurry` here.

Note that this is a breaking change for any client matching on `CExpr` (or using `trExpr` et al.), so perhaps a version bump would be appropriate?