### PR TITLE
Represent module exports in `CurryProg`

### DIFF
--- a/src/AbstractCurry/Build.curry
+++ b/src/AbstractCurry/Build.curry
@@ -18,7 +18,7 @@ infixr 9 ~>
 simpleCurryProg :: String -> [String] -> [CTypeDecl] -> [CFuncDecl] -> [COpDecl]
                 -> CurryProg
 simpleCurryProg name imps types funcs ops =
-  CurryProg name imps Nothing [] [] types funcs ops
+  CurryProg name [] imps Nothing [] [] types funcs ops
 
 ------------------------------------------------------------------------
 -- Goodies to construct type declarations

--- a/src/AbstractCurry/Select.curry
+++ b/src/AbstractCurry/Select.curry
@@ -34,15 +34,19 @@ import Data.List (union)
 
 -- Returns the name of a given Curry program.
 progName :: CurryProg -> String
-progName (CurryProg modname _ _ _ _ _ _ _) = modname
+progName (CurryProg modname _ _ _ _ _ _ _ _) = modname
+
+--- Returns the exports (module names) of a given Curry program.
+exports :: CurryProg -> [MName]
+exports (CurryProg _ ms _ _ _ _ _ _ _) = ms
 
 --- Returns the imports (module names) of a given Curry program.
 imports :: CurryProg -> [MName]
-imports (CurryProg _ ms _ _ _ _ _ _) = ms
+imports (CurryProg _ _ ms _ _ _ _ _ _) = ms
 
 --- Returns the function declarations of a given Curry program.
 functions :: CurryProg -> [CFuncDecl]
-functions (CurryProg _ _ _ _ _ _ fs _) = fs
+functions (CurryProg _ _ _ _ _ _ _ fs _) = fs
 
 --- Returns all constructors of given Curry program.
 constructors :: CurryProg -> [CConsDecl]
@@ -50,7 +54,7 @@ constructors = concatMap typeCons . types
 
 --- Returns the type declarations of a given Curry program.
 types :: CurryProg -> [CTypeDecl]
-types (CurryProg _ _ _ _ _ ts _ _) = ts
+types (CurryProg _ _ _ _ _ _ ts _ _) = ts
 
 --- Returns the names of all visible functions in given Curry program.
 publicFuncNames :: CurryProg -> [QName]

--- a/src/AbstractCurry/Types.curry
+++ b/src/AbstractCurry/Types.curry
@@ -43,10 +43,11 @@ data CVisibility
 --- Data type for representing a Curry module in the intermediate form.
 --- A value of this data type has the form
 ---
----     (CurryProg modname imports dfltdecl clsdecls instdecls typedecls
+---     (CurryProg modname exports imports dfltdecl clsdecls instdecls typedecls
 ---                funcdecls opdecls)
 ---
 --- where modname: name of this module,
+---       exports: list of modules names that are exported,
 ---       imports: list of modules names that are imported,
 ---       dfltdecl: optional default declaration
 ---       clsdecls:  Class declarations
@@ -54,7 +55,7 @@ data CVisibility
 ---       typedecls: Type declarations
 ---       functions: Function declarations
 ---       opdecls: Operator precedence declarations
-data CurryProg = CurryProg MName [MName] (Maybe CDefaultDecl) [CClassDecl]
+data CurryProg = CurryProg MName [MName] [MName] (Maybe CDefaultDecl) [CClassDecl]
                            [CInstanceDecl] [CTypeDecl] [CFuncDecl] [COpDecl]
   deriving (Eq, Show)
 


### PR DESCRIPTION
This updates `CurryProg` to include a list of exported module names before the list of imports:

```diff
-data CurryProg = CurryProg MName         [MName] (Maybe CDefaultDecl) [CClassDecl]
+data CurryProg = CurryProg MName [MName] [MName] (Maybe CDefaultDecl) [CClassDecl]
                                     ^
                                     |
                                  exports
```

i.e. something like `CurryProg "X" ["A", "B", "C"] ...` will be printed as

```curry
module X
  ( module A
  , module B
  , module C
  ) where
```

This came up during https://github.com/fwcd/curry-lsp/pull/6, since `AbstractCurry` had no way of re-exporting modules. Notably this is a breaking change and will require every library client that constructs or matches on `CurryProg` to update their code and, which will likely be nearly every program using the library, so a version bump is probably needed.